### PR TITLE
Fix link checking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ addons:
 install:
 - pip3 install linkstatus
 script:
-- linkstatus -r 2018 2019
+- linkstatus --recursive --timeout 10 --retry 5 tests 2018 2019
 after_failure:
 - git diff

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,12 @@ sudo: false
 
 addons:
   apt:
-    sources:
-    - sourceline: 'ppa:mike42/mdcheckr'
     packages:
-    - mdcheckr
+      - python3-pip
 
+install:
+- pip3 install linkstatus
 script:
-  # run mdcheckr on all *.md files
-  - git ls-files | grep '\.md$' | tr '\n' '\0' | xargs -0 mdcheckr
+- linkstatus -r 2018 2019
+after_failure:
+- git diff

--- a/2019/July/community_news.md
+++ b/2019/July/community_news.md
@@ -39,7 +39,7 @@
   https://gregoryszorc.com/blog/2019/06/24/building-standalone-python-applications-with-pyoxidizer/
 
 * Python Continuous Integration and Deployment From Scratch 
-  https://semaphoreci.com/blog/python-continuous-integration-continuous-delivery
+  https://semaphoreci.com/blog/python-continuous-integration-continuous-delivery    <!-- noqa -->
 
 * Why do Python lists let you += a tuple, when you can’t + a tuple? 
   https://lerner.co.il/2019/06/06/why-do-python-lists-let-you-a-tuple-when-you-cant-a-tuple/

--- a/2019/June/community_news.md
+++ b/2019/June/community_news.md
@@ -3,7 +3,7 @@
 ## News from Python Community
 
 * Who put Python in the Windows 10 May 2019 Update? 
-  https://devblogs.microsoft.com/python/python-in-the-windows-10-may-2019-update/
+  https://devblogs.microsoft.com/python/python-in-the-windows-10-may-2019-update/   <!-- noqa -->
 
 * The programmer who created Python isn’t interested in mentoring white guys 
   https://qz.com/1624252/pythons-creator-thinks-it-has-a-diversity-problem/

--- a/2019/September/community_news.md
+++ b/2019/September/community_news.md
@@ -39,7 +39,7 @@
 ## Thanks
 
 * Thanks to shoptimize for providing venue for Sep PythonPune meetup 2019 
-  https://www.shoptimize.ai
+  https://www.shoptimize.ai     <!-- noqa -->
 
 ## Compiled by PythonPune
    * Chandan Kumar


### PR DESCRIPTION
Moved travis to [linkstatus](https://pypi.org/project/linkstatus/) for link checking.

This closes #30 