### PR TITLE
Add new GitHub CFP form link in About us section

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -90,9 +90,8 @@ params:
           speakers specially the first timers to showcase their work
           or share their knowledge with everyone. All the variety of
           topics which are not just related to Python are
-          welcome. Submitting a talk is as easy as creating an [issue
-          on
-          GitHub](https://github.com/pythonpune/meetup-talks/issues/new?&labels=talk-proposal&template=propose-a-talk.md).
+          welcome. Submitting a talk is as easy as filling a [form on
+          GitHub](http://cfp.pythonpune.in).
         url: '#'
   recent:
     enable: false


### PR DESCRIPTION
Instead of traditional way of creating issue, now CFP accept with the
GitHub issue form.
