### PR TITLE
Migrating to Libera.Chat

### DIFF
--- a/.github/workflows/newsletter-issue.yml
+++ b/.github/workflows/newsletter-issue.yml
@@ -29,6 +29,7 @@ jobs:
       - name: IRC notification
         uses: Gottox/irc-message-action@v1
         with:
+          server: irc.libera.chat
           channel: ${{ secrets.CHANNEL }}
           nickname: pypune_${{ github.run_id }}
           message: |-

--- a/.github/workflows/notifications.yml
+++ b/.github/workflows/notifications.yml
@@ -19,11 +19,11 @@ jobs:
       - name: IRC notification
         uses: Gottox/irc-message-action@v1
         with:
+          server: irc.libera.chat
           channel: ${{ secrets.CHANNEL }}
           nickname: pypune_${{ github.run_id }}
           message: |-
-            New talk proposal submission: ${{ github.event.issue.title }}
-            ${{ github.event.issue.html_url }}
+            New talk proposal submission: ${{ github.event.issue.title }} ${{ github.event.issue.html_url }}
 
   newsletter-comment:
     # run only when comment on issue with label `newsletter`.
@@ -37,9 +37,9 @@ jobs:
       - name: IRC notification
         uses: Gottox/irc-message-action@v1
         with:
+          server: irc.libera.chat
           channel: ${{ secrets.CHANNEL }}
           nickname: pypune_${{ github.run_id }}_1
           message: |-
             ${{ github.event.comment.body }}
-            Submitted by: ${{ github.event.comment.user.login }}.
-            Have anything interesting to share? Add a comment here: ${{ github.event.comment.html_url }}
+            Submitted by: ${{ github.event.comment.user.login }}. Have anything interesting to share? Add a comment here: ${{ github.event.comment.html_url }}

--- a/config.yaml
+++ b/config.yaml
@@ -121,8 +121,8 @@ params:
         url: 'http://tel.pythonpune.in'
       - icon: fa-comments-o
         title: IRC Channel
-        description: 'Chat with us on IRC channel <b>#pythonpune</b> at freenode.'
-        url: 'https://webchat.freenode.net/#pythonpune'
+        description: 'Chat with us on IRC channel <b>#pythonpune</b> at Libera.Chat.'
+        url: 'https://kiwiirc.com/nextclient/#ircs://irc.libera.chat:6697/#pythonpune'
       - icon: fa-envelope-o
         title: Mailing list
         description: >-


### PR DESCRIPTION
- Update the homepage with Kiwi IRC join URL.
- Update all the workflows to point to irc.libera.chat
- Minimize the number of messages posted to IRC
